### PR TITLE
refactor: enhance API documentation and validation in DTOs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.9</version>
+		</dependency>
+		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>

--- a/src/main/java/br/com/jfabiodev/TwitterClone/config/OpenAPIConfig.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/config/OpenAPIConfig.java
@@ -1,0 +1,31 @@
+package br.com.jfabiodev.TwitterClone.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenAPIConfig {
+    @Bean
+    public OpenAPI customOpenAPI(){
+        final String securitySchemeName = "bearerAuth";
+
+        return  new OpenAPI().info(new Info().title("Twitter Clone API").version("1.0.1")
+                        .description("API documentation for the Twitter Clone project."))
+                .servers(List.of(
+                        new Server().url("http://localhost:8080").description("Local Server")
+                ))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components().addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                        .name(securitySchemeName).type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer").bearerFormat("JWT")
+                ));
+    }
+}

--- a/src/main/java/br/com/jfabiodev/TwitterClone/config/SecurityConfig.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/config/SecurityConfig.java
@@ -39,6 +39,12 @@ public class SecurityConfig {
         http.authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.POST, "/login").permitAll()
                         .requestMatchers(HttpMethod.POST, "/user/create").permitAll()
+                        .requestMatchers(
+                                "/docs/twitter-clone",
+                                "/swagger-ui/**",
+                                "/docs/twitter-clone/swagger-config",
+                                "/swagger-ui.html"
+                        ).permitAll()
                         .anyRequest().authenticated())
                 .csrf(csrf -> csrf.disable())
                 .oauth2ResourceServer(oauth2-> oauth2.jwt(Customizer.withDefaults()))

--- a/src/main/java/br/com/jfabiodev/TwitterClone/controller/PostController.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/controller/PostController.java
@@ -4,6 +4,10 @@ import br.com.jfabiodev.TwitterClone.dtos.CreatePostDTO;
 import br.com.jfabiodev.TwitterClone.dtos.FeedDTO;
 import br.com.jfabiodev.TwitterClone.dtos.PostResponseDTO;
 import br.com.jfabiodev.TwitterClone.service.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -12,6 +16,10 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 
+@Tag(
+        name = "Posts",
+        description = "Endpoints for creating, retrieving, and deleting posts."
+)
 @RestController
 public class PostController {
 
@@ -23,6 +31,11 @@ public class PostController {
     }
 
     @PostMapping("/create-post")
+    @Operation(summary = "Create new post",
+            description = "Creates a new post with the given content. Requires JWT authentication. Returns the created" +
+                    " post along with the Location header pointing to the new resource."
+    )
+    @Transactional
     public ResponseEntity<PostResponseDTO> createPost(@Valid @RequestBody CreatePostDTO dto, JwtAuthenticationToken token, UriComponentsBuilder uriBuilder){
         var response = postService.createPost(dto, token.getName());
         URI location = uriBuilder.path("/posts/{id}").buildAndExpand(response.postId()).toUri();
@@ -30,13 +43,23 @@ public class PostController {
     }
 
     @DeleteMapping("/post/{id}")
+    @Operation (summary = "Delete post by ID",
+            description = "Deletes a post tih the given ID. Only the post author or an administrator can perform this"+
+                    " action. Requires a valid JWT Token"
+    )
+    @Transactional
     public ResponseEntity<Void> deletePost(@PathVariable("id") Long id, JwtAuthenticationToken token){
         postService.deletePost(id, token.getName());
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/feed")
-    public ResponseEntity<FeedDTO> feed(@RequestParam(value = "page",defaultValue = "0") int page,
+    @Operation(summary = "Get public post feed",
+            description = "Retrieves a paginated list of recent posts. Requires JWT Token."
+    )
+    public ResponseEntity<FeedDTO> feed(@Parameter(description = "Page number (starting with 0)", example = "0")
+                                            @RequestParam(value = "page",defaultValue = "0") int page,
+                                        @Parameter(description = "Number of posts per page", example = "10")
                                         @RequestParam(value = "pageSize",defaultValue = "10") int pageSize){
         var feed = postService.getFeed(page, pageSize);
         return  ResponseEntity.ok(feed);

--- a/src/main/java/br/com/jfabiodev/TwitterClone/controller/TokenController.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/controller/TokenController.java
@@ -4,12 +4,18 @@ package br.com.jfabiodev.TwitterClone.controller;
 import br.com.jfabiodev.TwitterClone.dtos.LoginDTO;
 import br.com.jfabiodev.TwitterClone.dtos.LoginResponseDTO;
 import br.com.jfabiodev.TwitterClone.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(
+        name = "Authentication",
+        description = "Endpoints related to user authentication and JWT token generation."
+)
 @RestController
 public class TokenController {
 
@@ -19,6 +25,9 @@ public class TokenController {
     }
 
     @PostMapping("/login")
+    @Operation(summary = "Authenticate user and return JWT Token",
+            description = "Validates the provided credentials and returns a JWT Token if authentication is successful. " +
+                    "This token must be used for accessing protected endpoints.")
     public ResponseEntity<LoginResponseDTO> login(@Valid @RequestBody LoginDTO loginDTO){
        var response = authService.authenticate(loginDTO);
        return ResponseEntity.ok(response);

--- a/src/main/java/br/com/jfabiodev/TwitterClone/controller/UserController.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/controller/UserController.java
@@ -4,6 +4,8 @@ import br.com.jfabiodev.TwitterClone.dtos.CreateUserDTO;
 import br.com.jfabiodev.TwitterClone.dtos.CreateUserResponseDTO;
 import br.com.jfabiodev.TwitterClone.dtos.UserListResponseDTO;
 import br.com.jfabiodev.TwitterClone.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +19,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.net.URI;
 import java.util.List;
 
+@Tag(name = "User Management", description = "Endpoints for user registration and listing")
 @RestController
 public class UserController {
 
@@ -28,6 +31,8 @@ public class UserController {
 
     @Transactional
     @PostMapping("/user/create")
+    @Operation(summary = "Register a new user", description = "Creates a new user account with the provided username" +
+            " and password. Returns the user's ID and username upon successful creation.")
     public ResponseEntity<CreateUserResponseDTO> createUser (@Valid @RequestBody CreateUserDTO createUserDTO, UriComponentsBuilder uriBuilder){
         var response =  userService.createUser(createUserDTO);
         URI location = uriBuilder.path("/user/{id}").buildAndExpand(response.userId()).toUri();
@@ -36,6 +41,8 @@ public class UserController {
 
     @PreAuthorize("hasAuthority('SCOPE_ADMIN')")
     @GetMapping("/users")
+    @Operation(summary = "List all users",description = "Returns a list of all registered users. This endpoint is " +
+            "restricted to users with ADMIN privileges.")
     public ResponseEntity<List<UserListResponseDTO>> listUsers(){
        return ResponseEntity.ok(userService.listAllUsers());
     }

--- a/src/main/java/br/com/jfabiodev/TwitterClone/dtos/CreatePostDTO.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/dtos/CreatePostDTO.java
@@ -1,6 +1,11 @@
 package br.com.jfabiodev.TwitterClone.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-public record CreatePostDTO(@NotBlank(message = "Content should not be blank") String content) {
+public record CreatePostDTO(
+        @NotBlank(message = "Content should not be blank")
+        @Schema(description = "Content of the post. Cannot be blank.",
+                example ="Hello world :) This is my first post") String content
+) {
 }

--- a/src/main/java/br/com/jfabiodev/TwitterClone/dtos/CreateUserDTO.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/dtos/CreateUserDTO.java
@@ -1,7 +1,11 @@
 package br.com.jfabiodev.TwitterClone.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-public record CreateUserDTO (@NotBlank(message = "Username should not be blank") String username,
-                             @NotBlank(message = "Password should not be blank") String password) {
-}
+public record CreateUserDTO (@NotBlank(message = "Username should not be blank") @Schema(
+        description = "The desired username for the new user. Must be unique and not blank.",
+        example = "jfabio") String username,
+                             @NotBlank(message = "Password should not be blank") @Schema(
+                                     description = "The password for the new user. Must not be blank",
+                                     example = "minhasenha123") String password) {}

--- a/src/main/java/br/com/jfabiodev/TwitterClone/dtos/CreateUserResponseDTO.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/dtos/CreateUserResponseDTO.java
@@ -1,7 +1,10 @@
 package br.com.jfabiodev.TwitterClone.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.UUID;
 
-public record CreateUserResponseDTO(UUID userId,
-                                    String username) {
+public record CreateUserResponseDTO(@Schema(description = "Unique identifier of the newly created user.",
+        example = "3fa85f64-5717-4562-b3fc-2c963f66afa6") UUID userId,
+                                    @Schema(description = "Username of the newly created user.", example = "jfabio") String username) {
 }

--- a/src/main/java/br/com/jfabiodev/TwitterClone/dtos/FeedDTO.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/dtos/FeedDTO.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
-public record FeedDTO(@NotNull @Valid List<FeedItemDTO> feedItems,
+public record FeedDTO(@NotNull @Valid @Schema(description = "List of feed items") List<FeedItemDTO> feedItems,
                       @Schema(description = "Curret page number", example = "0") int page,
                       @Schema(description = "Number of items per page", example = "10") int pageSize,
                       @Schema(description = "Total number of pages", example = "5") int totalPages,

--- a/src/main/java/br/com/jfabiodev/TwitterClone/dtos/FeedDTO.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/dtos/FeedDTO.java
@@ -1,14 +1,15 @@
 package br.com.jfabiodev.TwitterClone.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
 public record FeedDTO(@NotNull @Valid List<FeedItemDTO> feedItems,
-                      int page,
-                      int pageSize,
-                      int totalPages,
-                      long totalElements
+                      @Schema(description = "Curret page number", example = "0") int page,
+                      @Schema(description = "Number of items per page", example = "10") int pageSize,
+                      @Schema(description = "Total number of pages", example = "5") int totalPages,
+                      @Schema(description = "Total of feed items", example = "50") long totalElements
 ) {
 }

--- a/src/main/java/br/com/jfabiodev/TwitterClone/dtos/FeedItemDTO.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/dtos/FeedItemDTO.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record FeedItemDTO(@NotNull(message = "Post ID is Required") @Schema(description = "Unique identifier post",
+public record FeedItemDTO(@NotNull(message = "Post ID is Required") @Schema(description = "Unique identifier of the post",
         example = "2") Long postId,
                           @NotBlank(message = "Content should not be blank") @Schema(description = "Content of the post",
                                   example = "Hello, world!") String content,

--- a/src/main/java/br/com/jfabiodev/TwitterClone/dtos/FeedItemDTO.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/dtos/FeedItemDTO.java
@@ -1,9 +1,13 @@
 package br.com.jfabiodev.TwitterClone.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record FeedItemDTO(@NotNull (message = "Post ID is Required") Long postId,
-                          @NotBlank(message = "Content should not be blank") String content,
-                          @NotBlank(message = "Username should not be blank") String username) {
+public record FeedItemDTO(@NotNull(message = "Post ID is Required") @Schema(description = "Unique identifier post",
+        example = "2") Long postId,
+                          @NotBlank(message = "Content should not be blank") @Schema(description = "Content of the post",
+                                  example = "Hello, world!") String content,
+                          @NotBlank(message = "Username should not be blank") @Schema(description = "Username of the post author",
+                          example = "admin") String username) {
 }

--- a/src/main/java/br/com/jfabiodev/TwitterClone/dtos/LoginDTO.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/dtos/LoginDTO.java
@@ -1,7 +1,9 @@
 package br.com.jfabiodev.TwitterClone.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-public record LoginDTO (@NotBlank(message = "Username should not be blank") String username,
-                        @NotBlank(message = "Password should not be blank") String password) {
-}
+public record LoginDTO (@NotBlank(message = "Username should not be blank") @Schema(description = "The username used " +
+        "for authentication. Must not be blank", example = "admin") String username,
+                        @NotBlank(message = "Password should not be blank") @Schema(description = "The password associ" +
+                                "ated with the given username. Must not be blank", example = "1234") String password) {}

--- a/src/main/java/br/com/jfabiodev/TwitterClone/dtos/LoginResponseDTO.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/dtos/LoginResponseDTO.java
@@ -1,4 +1,8 @@
 package br.com.jfabiodev.TwitterClone.dtos;
 
-public record LoginResponseDTO(String acessToken, Long expiresIn) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LoginResponseDTO(@Schema(description ="The JWT token issued after successful authentication. " +
+        "Used to authorize requests to protected endpoints.", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...") String accessToken,
+                               @Schema(description = "Time in seconds until the access token expires.", example = "3600") Long expiresIn) {
 }

--- a/src/main/java/br/com/jfabiodev/TwitterClone/dtos/PostResponseDTO.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/dtos/PostResponseDTO.java
@@ -1,6 +1,9 @@
 package br.com.jfabiodev.TwitterClone.dtos;
 
-public record PostResponseDTO(Long postId,
-                             String content,
-                             String username,
-                             String createdAt) {}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PostResponseDTO(@Schema(description = "Unique identifier of post", example = "101") Long postId,
+                              @Schema(description = "Content of the post", example = "Hello world :) This is my first post") String content,
+                              @Schema(description = "Username of the post author", example = "admin") String username,
+                              @Schema(description = "Creation timestamp of the post in ISO format",
+                              example = "2025-06-22T15:30:00Z") String createdAt) {}

--- a/src/main/java/br/com/jfabiodev/TwitterClone/dtos/UserListResponseDTO.java
+++ b/src/main/java/br/com/jfabiodev/TwitterClone/dtos/UserListResponseDTO.java
@@ -1,9 +1,11 @@
 package br.com.jfabiodev.TwitterClone.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Set;
 import java.util.UUID;
 
-public record UserListResponseDTO(UUID userId,
-                                  String username,
-                                  Set<String> roles) {
+public record UserListResponseDTO(@Schema(description = "Unique identifier of the user", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6") UUID userId,
+                                  @Schema(description = "Username of the user",example = "jfabio") String username,
+                                  @Schema(description = "Set of roles assigned to the user.", example = "[\"BASIC\"]") Set<String> roles) {
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 jwt.public.key=classpath:app.pub
 jwt.private.key=classpath:app.key
 
+springdoc.api-docs.path=/docs/twitter-clone
+springdoc.swagger-ui.url=/docs/twitter-clone
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.datasource.url=jdbc:mysql://localhost:3306/twitter_clone_flyway
 spring.datasource.username=root


### PR DESCRIPTION
This pull request introduces OpenAPI documentation to the Twitter Clone project, enhancing API usability and clarity. It includes the integration of the SpringDoc library, configuration for API documentation, and annotations across controllers and DTOs to describe endpoints and data structures.

### OpenAPI Integration:

* Added `springdoc-openapi-starter-webmvc-ui` dependency to `pom.xml` for OpenAPI support.
* Created `OpenAPIConfig` class to configure API metadata, security schemes, and server details.
* Updated `application.properties` to define custom paths for API documentation and Swagger UI.

### Controller Enhancements:

* Annotated controllers (`PostController`, `TokenController`, `UserController`) with `@Tag` and `@Operation` to document endpoints, including descriptions, summaries, and security requirements. [[1]](diffhunk://#diff-98b806a80725a43429dbbee7f5d285b5432d9c25fe30c54e51147e8163ff22abR19-R22) [[2]](diffhunk://#diff-8a9b07f6f7e685ae0b4a0de671ce6aac7e3e258b8f11dd5eeaf028b9c642496fR28-R30) [[3]](diffhunk://#diff-44c0d235d8353c29f9bc47ff25465d8b897d4485c0990b541464756edfc702efR44-R45)

### DTO Annotations:

* Added `@Schema` annotations to DTOs (`CreatePostDTO`, `CreateUserDTO`, `PostResponseDTO`, etc.) to describe fields, constraints, and examples for better documentation. [[1]](diffhunk://#diff-4ebc3b769b39f5978f1f81338c9671a06264b15d45527ad7251439ce82e03a8aR3-R10) [[2]](diffhunk://#diff-b9b52b0af9972eee0938d175a8fc5678cf649cdfaf830995a476d207d390231eR3-R11) [[3]](diffhunk://#diff-8c5af289d001569a78eb50349786ac413f04f418a3d3d837bc024f19cbce54d1L3-R9)

### Security Configuration:

* Updated `SecurityConfig` to allow unauthenticated access to API documentation endpoints.